### PR TITLE
Faster drawing without framebuffer

### DIFF
--- a/TFT_ILI9163C.cpp
+++ b/TFT_ILI9163C.cpp
@@ -303,8 +303,9 @@ void TFT_ILI9163C::writeRow(uint16_t row, uint16_t row_start, uint16_t row_len, 
 #ifndef FRAMEBUFFER
 void TFT_ILI9163C::drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color) {
     uint8_t buf[w * 2];
+    uint16_t color_sw = uint8_t(color >> 8) | uint8_t(color) << 8;
     for (int16_t i = 0; i < w; ++i) {
-        ((uint16_t*)buf)[i] = color;
+        ((uint16_t*)buf)[i] = color_sw;
     }
     writeRow(y, x, w, buf);
 }

--- a/TFT_ILI9163C.cpp
+++ b/TFT_ILI9163C.cpp
@@ -5,8 +5,6 @@
 #include <SPI.h>
 
 
-#define FRAMEBUFFER
-
 #if defined(SPI_HAS_TRANSACTION)
 	static SPISettings ILI9163C_SPI;
 #endif
@@ -288,6 +286,36 @@ void TFT_ILI9163C::writeFramebuffer() {
 #else
 void TFT_ILI9163C::writeFramebuffer() {	
 	//nop 
+}
+#endif
+
+void TFT_ILI9163C::writeRow(uint16_t row, uint16_t row_start, uint16_t row_len, uint8_t * data) {	
+#ifndef FRAMEBUFFER 
+	setAddrWindow(row_start, row, row_start + row_len, row+1);
+	writeScreen16(data, row_len * 2);
+#else
+    for (uint16_t i = 0; i < row_len; ++i) {
+        drawPixel(i + row_start, row, data[i * 2] << 8 | data[i * 2 + 1]);
+    }
+#endif
+}
+
+#ifndef FRAMEBUFFER
+void TFT_ILI9163C::drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color) {
+    uint8_t buf[w * 2];
+    for (int16_t i = 0; i < w; ++i) {
+        ((uint16_t*)buf)[i] = color;
+    }
+    writeRow(y, x, w, buf);
+}
+
+void TFT_ILI9163C::fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color) {
+    // Update in subclasses if desired!
+    startWrite();
+    for (int16_t i=y; i<y+h; i++) {
+        writeFastHLine(x, i, w, color);
+    }
+    endWrite();
 }
 #endif
 

--- a/TFT_ILI9163C.h
+++ b/TFT_ILI9163C.h
@@ -124,6 +124,8 @@ This Library has a Framebuffer added, the esp8266 is too slow for normal usage D
 
 #include "_settings/TFT_ILI9163C_registers.h"
 
+#define FRAMEBUFFER
+
 
 class TFT_ILI9163C : public Adafruit_GFX {
 
@@ -147,6 +149,11 @@ class TFT_ILI9163C : public Adafruit_GFX {
 	void 		pushData(uint16_t color);
 	void 		endPushData();
 	void		writeFramebuffer();
+	void		writeRow(uint16_t row, uint16_t row_start, uint16_t row_len, uint8_t * rowdata);
+#ifndef FRAMEBUFFER
+    void        drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color) override;
+    void        fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color) override;
+#endif
 	void		writeScreen24(const uint32_t *bitmap,uint16_t size=_TFTWIDTH*_TFTHEIGHT*2);
 	void		writeScreen16(uint8_t *bitmap,uint32_t size=_TFTWIDTH*_TFTHEIGHT*2);
 	inline uint16_t Color565(uint8_t r, uint8_t g, uint8_t b) {return ((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3);};


### PR DESCRIPTION
With these changes the ui is reasonably fast without using the
framebuffer. This saves us 32k memory which improves stability.